### PR TITLE
Add hackathons schema and update bot to load messages from text channels

### DIFF
--- a/apps/bot/env.ts
+++ b/apps/bot/env.ts
@@ -19,7 +19,7 @@ export const env = createEnv({
     MODERATOR_ROLE_ID: z.string().optional(),
     HELPER_ROLE_ID: z.string().optional(),
     REGULAR_MEMBER_ROLE_ID: z.string().optional(),
-    INDEXABLE_CHANNEL_IDS: z.string().transform((str) => str.split(',')),
+    INDEXABLE_CATEGORY_IDS: z.string().transform((str) => str.split(',')),
     MOD_LOG_CHANNEL_ID: z.string().optional(),
     GUIDELINES_MESSAGE: z
       .string()

--- a/apps/bot/utils.ts
+++ b/apps/bot/utils.ts
@@ -1,5 +1,4 @@
 import {
-  AnyThreadChannel,
   APIEmbed,
   Channel,
   ChannelType,
@@ -21,13 +20,13 @@ import { unindexPost } from './db/actions/posts.js'
 
 const START_INDEXING_AFTER = 1686438000000
 
-export const isMessageInForumChannel = (
+export const isMessageInCategoryChannel = (
   channel: Channel,
-): channel is AnyThreadChannel<true> => {
+): channel is Channel => {
   return (
-    channel.isThread() &&
+    channel.isTextBased() &&
     channel.parentId !== null &&
-    env.INDEXABLE_CHANNEL_IDS.includes(channel.parentId)
+    env.INDEXABLE_CATEGORY_IDS.includes(channel.parentId)
   )
 }
 
@@ -36,17 +35,17 @@ export const isMessageSupported = (message: Message) => {
   return !message.author.bot && !message.system && isIndexable
 }
 
-export const isThreadSupported = (thread: AnyThreadChannel<true>) => {
+export const isThreadSupported = (channel: Channel) => {
   return (
-    thread.createdAt !== null &&
-    thread.createdAt.getTime() > START_INDEXING_AFTER
+    channel.createdAt !== null &&
+    channel.createdAt.getTime() > START_INDEXING_AFTER
   )
 }
 
-export const isThreadInForumChannel = (thread: AnyThreadChannel<true>) => {
+export const isThreadInForumChannel = (channel: Channel) => {
   return (
-    thread.parentId !== null &&
-    env.INDEXABLE_CHANNEL_IDS.includes(thread.parentId)
+    channel.parentId !== null &&
+    env.INDEXABLE_CATEGORY_IDS.includes(channel.parentId)
   )
 }
 
@@ -158,7 +157,7 @@ export const checkInvalidAnswer = async (
     | ChatInputCommandInteraction
     | MessageContextMenuCommandInteraction,
 ) => {
-  if (!interaction.channel || !isMessageInForumChannel(interaction.channel)) {
+  if (!interaction.channel || !isMessageInCategoryChannel(interaction.channel)) {
     await replyWithEmbedError(interaction, {
       description: 'This command can only be used in a supported forum channel',
     })
@@ -196,6 +195,6 @@ export const checkInvalidAnswer = async (
 
     return
   }
-  const channel = interaction.channel as AnyThreadChannel<true>
+  const channel = interaction.channel
   return { channel, interactionMember, mainChannel }
 }

--- a/packages/db/migrations/7-hackathons-schema.ts
+++ b/packages/db/migrations/7-hackathons-schema.ts
@@ -1,0 +1,23 @@
+import { Kysely } from 'kysely'
+import { SnowflakeDataType, uuidColumnBuilder } from '../migrations-utils.js'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // --- Categories
+  await db.schema
+    .createTable('categories')
+    .addColumn('id', 'uuid', uuidColumnBuilder)
+    .addColumn('name', 'text', (col) => col.notNull())
+    .addColumn('description', 'text', (col) => col.notNull())
+    .execute()
+
+  // --- Channels
+  await db.schema
+    .alterTable('channels')
+    .addColumn('categoryId', 'uuid', (col) => col.references('categories.id'))
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('channels').dropColumn('categoryId').execute()
+  await db.schema.dropTable('categories').execute()
+}

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -22,6 +22,13 @@ export interface Channels {
   snowflakeId: string
   topic: string
   type: number
+  categoryId: string | null
+}
+
+export interface Categories {
+  id: Generated<string>
+  name: string
+  description: string
 }
 
 export interface Messages {
@@ -65,6 +72,7 @@ export interface Users {
 export interface DB {
   attachments: Attachments
   channels: Channels
+  categories: Categories
   messages: Messages
   posts: Posts
   users: Users


### PR DESCRIPTION
Add a new schema for a community that shares hackathons with categories and channels.

* **Schema Changes**
  - Add `categories` table with columns `id`, `name`, and `description` in `packages/db/migrations/7-hackathons-schema.ts`.
  - Add `categoryId` column to `channels` table to link channels to categories.

* **Environment Variables**
  - Add `INDEXABLE_CATEGORY_IDS` environment variable in `apps/bot/env.ts`.
  - Remove `INDEXABLE_CHANNEL_IDS` environment variable.

* **Bot Message Handling**
  - Update the bot's on message code in `apps/bot/index.ts` to load messages from text channels within specified categories.
  - Use `INDEXABLE_CATEGORY_IDS` to filter messages from text channels.

* **Utility Functions**
  - Remove `isMessageInForumChannel` function in `apps/bot/utils.ts`.
  - Add `isMessageInCategoryChannel` function to check if a message is in a text channel within specified categories.
  - Remove any checks for `thread.{x}` or `AnyThreadChannel`.

* **Schema Definition**
  - Remove `INDEXABLE_CHANNEL_IDS` and update everything along the lines of "Thread" to work for channels in `packages/db/schema.ts`.

