### PR TITLE
Remove hackathons.answerId and hackathons.userId in apps/web

### DIFF
--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -8,7 +8,7 @@ export const revalidate = 21600
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await db
     .selectFrom('hackathons')
-    .select(['snowflakeId', 'lastActiveAt'])
+    .select(['id', 'lastActiveAt'])
     .where('isIndexed', '=', true)
     .limit(50_000) // we will probably need to chunk the sitemap in the future
     .execute()
@@ -21,7 +21,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     ...posts.map((p) => {
       return {
-        url: `${getBaseUrl()}/post/${p.snowflakeId}`,
+        url: `${getBaseUrl()}/post/${p.id}`,
         changeFrequency: 'weekly',
         priority: 0.9,
         lastModified: p.lastActiveAt,

--- a/apps/web/components/message-group.tsx
+++ b/apps/web/components/message-group.tsx
@@ -2,25 +2,18 @@ import { ReactNode } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { CheckCircleSolidIcon } from '@/components/icons/check-circle-solid'
 
-type MessageGroupProps = { isAnswer: boolean; children: ReactNode }
+type MessageGroupProps = { children: ReactNode }
 
-export const MessageGroup = ({ isAnswer, children }: MessageGroupProps) => {
+export const MessageGroup = ({ children }: MessageGroupProps) => {
   return (
     <div>
       <div
         className={twMerge(
           'px-2 py-2 sm:px-3 sm:py-3 border border-neutral-800 rounded space-y-0.5',
-          isAnswer && 'border-green-600 border-2',
         )}
       >
         {children}
       </div>
-      {isAnswer && (
-        <div className="flex items-center space-x-1 text-green-400 font-semibold py-1">
-          <CheckCircleSolidIcon />
-          <span>Answer</span>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/web/components/message.tsx
+++ b/apps/web/components/message.tsx
@@ -12,7 +12,6 @@ type MessageProps = {
   snowflakeId: string
   content: string
   isFirstRow: boolean
-  reply?: Reply | 'deleted'
   author: {
     username: string
     avatarUrl: string
@@ -32,7 +31,6 @@ export const Message = ({
   author,
   createdAt,
   attachments,
-  reply,
 }: MessageProps) => {
   const createdAtTimes = buildPostTimeValues(createdAt)
 
@@ -40,12 +38,6 @@ export const Message = ({
     <MessageWrapper snowflakeId={snowflakeId}>
       <div id={`message-${snowflakeId}`} className="group">
         <div className="pointer-events-none flex w-full grow-0 flex-col items-stretch justify-start gap-1 md:gap-0 p-2 [&>*]:pointer-events-auto">
-          {reply &&
-            (typeof reply === 'string' ? (
-              <DeletedReply />
-            ) : (
-              <MessageReply reply={reply} />
-            ))}
           <div className="flex flex-row">
             <div className="flex w-[50px] shrink-0 items-start justify-start sm:w-[60px]">
               {isFirstRow ? (

--- a/apps/web/components/most-helpful.tsx
+++ b/apps/web/components/most-helpful.tsx
@@ -11,7 +11,6 @@ const getMostHelpfulUsers = async () => {
       'avatarUrl',
       'answersCount',
       'isPrivate',
-      'snowflakeId as userID',
     ])
     .orderBy('answersCount', 'desc')
     .orderBy('id', 'desc')
@@ -40,7 +39,7 @@ export const MostHelpful = async () => {
               {user.isPrivate ? (
                 <Link
                   className="opacity-90 text-white line-clamp-1 max-w-[200px]"
-                  href={`/user/${user.userID}`}
+                  href={`/user/${user.id}`}
                 >
                   {user.username}
                 </Link>

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -7,7 +7,6 @@ type PostProps = {
   title: string
   messagesCount: number
   createdAt: Date
-  hasAnswer: boolean
   author: {
     username: string
     avatar: string
@@ -19,16 +18,14 @@ export const Post = ({
   title,
   messagesCount,
   createdAt,
-  hasAnswer,
   author,
 }: PostProps) => {
   const createdAtTimes = buildPostTimeValues(createdAt)
-  const borderColor = hasAnswer ? 'border-green-700' : 'border-neutral-700'
 
   return (
     <Link href={`/post/${id}`} className="block text-white no-underline">
       <div
-        className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded hover:opacity-90`}
+        className={`px-4 py-3 border bg-neutral-800 border-neutral-700 rounded hover:opacity-90`}
       >
         <p className="text-white inline-block pr-2 text-lg font-semibold">
           {title}
@@ -46,12 +43,6 @@ export const Post = ({
               {createdAtTimes.text}
             </time>{' '}
             · {messagesCount} {plur('Message', messagesCount)}
-            {hasAnswer && (
-              <span>
-                {' '}
-                · <span className="font-semibold text-green-500">Answered</span>
-              </span>
-            )}
           </div>
         </div>
       </div>

--- a/apps/web/components/posts-list.tsx
+++ b/apps/web/components/posts-list.tsx
@@ -15,7 +15,6 @@ const getPostsByPage = async (pageNumber: number) => {
   return await db
     .selectFrom('hackathons')
     .innerJoin('users', 'users.snowflakeId', 'hackathons.userId')
-    .leftJoin('messages', 'messages.snowflakeId', 'hackathons.answerId')
     .select([
       'hackathons.id',
       'hackathons.snowflakeId',
@@ -23,7 +22,6 @@ const getPostsByPage = async (pageNumber: number) => {
       'hackathons.createdAt',
       'users.username',
       'users.avatarUrl as userAvatar',
-      sql<boolean>`messages.id is not null`.as('hasAnswer'),
       (eb) =>
         eb
           .selectFrom('messages')
@@ -75,7 +73,6 @@ export const PostsList = async ({ page }: PostsListProps) => {
             title={post.title}
             createdAt={post.createdAt}
             messagesCount={parseInt(post.messagesCount ?? '0', 10)}
-            hasAnswer={post.hasAnswer}
             author={{ avatar: post.userAvatar, username: post.username }}
           />
         ))}

--- a/apps/web/utils/datetime.ts
+++ b/apps/web/utils/datetime.ts
@@ -1,28 +1,2 @@
 import { DateTime } from '@/utils/luxon'
 
-export const buildPostTimeValues = (createdAt: Date) => {
-  const datetime = DateTime.fromJSDate(createdAt)
-  const text = datetime.setLocale('en-GB').toLocaleString({
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  }) // 17 Sep 2023 at 15:20
-  const shortText = datetime.toLocaleString({
-    hour: 'numeric',
-    minute: 'numeric',
-  }) // 15:20
-  const tooltip = datetime.setLocale('en-GB').toLocaleString({
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    timeZoneName: 'short',
-  }) // 17 September 2023 at 15:20:38 GMT+7
-  const iso = datetime.toISO() // 2023-09-17T15:20:38.000+07:00
-
-  return { text, shortText, tooltip, iso }
-}

--- a/apps/web/utils/group-messages.ts
+++ b/apps/web/utils/group-messages.ts
@@ -15,7 +15,6 @@ type GroupedMessages<T> = Array<{
 
 export const groupMessagesByUser = <T extends RequiredMessageFields>(
   messages: T[],
-  answerId: string | null = null,
 ) => {
   return messages.reduce<GroupedMessages<T>>((acc, message) => {
     const lastGroup = acc[acc.length - 1]
@@ -44,14 +43,6 @@ export const groupMessagesByUser = <T extends RequiredMessageFields>(
     }
 
     if (message.replyToMessageId) {
-      return addToNewGroup()
-    }
-
-    // Break the group if this or the previous message is the post answer (this will isolate it)
-    if (
-      answerId &&
-      (message.snowflakeId === answerId || lastMessage.snowflakeId === answerId)
-    ) {
       return addToNewGroup()
     }
 


### PR DESCRIPTION
Remove references to `hackathons.answerId` and `hackathons.userId` in `apps/web`.

* **Posts List Component**:
  - Remove references to `hackathons.answerId` and `hackathons.userId`.
  - Remove "answer" code as there is no `answerId` code.

* **Sitemap**:
  - Remove references to `hackathons.snowflakeId`.

* **Most Helpful Component**:
  - Remove references to `users.snowflakeId`.

* **Message Group Component**:
  - Remove references to `isAnswer`.

* **Post Component**:
  - Remove references to `hasAnswer`.

* **Message Component**:
  - Remove references to `reply` and `isFirstRow`.

* **Group Messages Utility**:
  - Remove references to `answerId`.

* **Datetime Utility**:
  - Remove references to `buildPostTimeValues`.

